### PR TITLE
Fix compilation error on ROS Melodic on Ubuntu 18.04

### DIFF
--- a/src/image_processor_nodelet.cpp
+++ b/src/image_processor_nodelet.cpp
@@ -17,8 +17,8 @@ void ImageProcessorNodelet::onInit() {
   return;
 }
 
-PLUGINLIB_DECLARE_CLASS(msckf_vio, ImageProcessorNodelet,
-    msckf_vio::ImageProcessorNodelet, nodelet::Nodelet);
+PLUGINLIB_EXPORT_CLASS(msckf_vio::ImageProcessorNodelet,
+    nodelet::Nodelet);
 
 } // end namespace msckf_vio
 

--- a/src/msckf_vio_nodelet.cpp
+++ b/src/msckf_vio_nodelet.cpp
@@ -17,8 +17,8 @@ void MsckfVioNodelet::onInit() {
   return;
 }
 
-PLUGINLIB_DECLARE_CLASS(msckf_vio, MsckfVioNodelet,
-    msckf_vio::MsckfVioNodelet, nodelet::Nodelet);
+PLUGINLIB_EXPORT_CLASS(msckf_vio::MsckfVioNodelet,
+    nodelet::Nodelet);
 
 } // end namespace msckf_vio
 


### PR DESCRIPTION
Use `PLUGINLIB_EXPORT_CLASS` instead of the deprecated `PLUGINLIB_DECLARE_CLASS`.