### PR TITLE
actually use the keyframe thresholds from the params

### DIFF
--- a/src/msckf_vio.cpp
+++ b/src/msckf_vio.cpp
@@ -1160,8 +1160,9 @@ void MsckfVio::findRedundantCamStates(
     double angle = AngleAxisd(
         rotation*key_rotation.transpose()).angle();
 
-    //if (angle < 0.1745 && distance < 0.2 && tracking_rate > 0.5) {
-    if (angle < 0.2618 && distance < 0.4 && tracking_rate > 0.5) {
+    if (angle < rotation_threshold &&
+        distance < translation_threshold &&
+        tracking_rate > tracking_rate_threshold) {
       rm_cam_state_ids.push_back(cam_state_iter->first);
       ++cam_state_iter;
     } else {


### PR DESCRIPTION
The keyframe thresholds set in the parameters are not used--instead the same values are hard-coded into the keyframing logic. This PR simply replaces those hard-coded values with the variables that already hold the values read from the config.